### PR TITLE
Fix CI: Update Python test matrix to match project requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Remove Python 3.8 (project requires >=3.9 per pyproject.toml)
- Add Python 3.13 to match the classifiers in pyproject.toml